### PR TITLE
APIリクエストのエラーコード返信時にmessageを表示する

### DIFF
--- a/assets/src/utils.js
+++ b/assets/src/utils.js
@@ -40,6 +40,11 @@ export const ajaxForm = (form, callback) => {
             })
           }
         })
+        .catch(err => {
+          err.response.data.errors.forEach(error => {
+              Notify.activate('danger', error.message)
+          })
+        })
         .finally(() => {
           callback()
           $submitButton.classList.remove('is-loading')


### PR DESCRIPTION
ajaxでAPIのリクエストを送った際に、400コード等の場合でもメッセージを表示するようにしておきました