### PR TITLE
Comment user prefix

### DIFF
--- a/ajax/models.py
+++ b/ajax/models.py
@@ -14,19 +14,19 @@ class Comment(models.Model):
     created_at = models.DateTimeField('作成日', default=timezone.now)
 
     @property
-    def name(self):
+    def user_name(self):
         if self.is_anonymous:
             return get_anonymous_name(self.user.username)
         return self.user.name
 
     @property
-    def username(self):
+    def user_username(self):
         if self.is_anonymous:
             return ""
         return self.user.username
 
     @property
-    def profile_icon_url(self):
+    def user_profile_icon_url(self):
         if self.is_anonymous:
             return '/assets/images/default-icon.png'
         return self.user.profile_icon_url
@@ -37,9 +37,9 @@ class Comment(models.Model):
             is_mine = user.username == self.user.username
         return {
             'id': self.id,
-            'name': self.name,
-            'username': self.username,
-            'profile_icon_url': self.profile_icon_url,
+            'name': self.user_name,
+            'username': self.user_username,
+            'profile_icon_url': self.user_profile_icon_url,
             'is_anonymous': self.is_anonymous,
             'is_mine': is_mine,
             'text': self.transed_text,

--- a/notify/models.py
+++ b/notify/models.py
@@ -36,7 +36,7 @@ class Notification(models.Model):
         # 匿名コメントに対応するため
         # notification-item.html内でプロフィールアイコンのみコンポーネント化していない
         if self.type == 'comment':
-            return self.target.profile_icon_url
+            return self.target.user_profile_icon_url
         return self.sender.profile_icon_url
 
     @property

--- a/notify/templates/notify/components/notification-item.html
+++ b/notify/templates/notify/components/notification-item.html
@@ -2,11 +2,7 @@
 <article class="media">
   <figure class="media-left">
     <p class="image is-32x32">
-      {% if notification.target.is_anonymous %}
-        <img src="{{ notification.target.user_profile_icon_url }}">
-      {% else%}
-        <img src="{{ notification.sender_profile_icon_url }}">
-      {% endif %}
+      <img src="{{ notification.sender_profile_icon_url }}">
     </p>
   </figure>
   <div class="media-content">

--- a/notify/templates/notify/components/notification-item.html
+++ b/notify/templates/notify/components/notification-item.html
@@ -2,7 +2,11 @@
 <article class="media">
   <figure class="media-left">
     <p class="image is-32x32">
-      <img src="{{ notification.sender_profile_icon_url }}">
+      {% if notification.target.is_anonymous %}
+        <img src="{{ notification.target.user_profile_icon_url }}">
+      {% else%}
+        <img src="{{ notification.sender_profile_icon_url }}">
+      {% endif %}
     </p>
   </figure>
   <div class="media-content">

--- a/notify/templates/notify/components/types/comment.html
+++ b/notify/templates/notify/components/types/comment.html
@@ -1,10 +1,10 @@
 {% load core_tags %}
 <strong>
   {% if target.is_anonymous %}
-    {{ target.name }}
+    {{ target.user_name }}
   {% else %}
-    <a href="{{ '/u/'|add:target.username|to_absolute_path }}">
-      {{ target.name }}(@{{ target.username }})
+    <a href="{{ '/u/'|add:target.user_username|to_absolute_path }}">
+      {{ target.user_name }}(@{{ target.user_username }})
     </a>
   {% endif %}
   さんが


### PR DESCRIPTION
#48 におけるCommentモデルの匿名対応用メソッドのプレフィックス付与について修正しました
以下について確認済みです

* コメントが表示されるページが正常に表示
* 匿名コメント及び通常コメントの投稿
* コメント付与動画の投稿者における通知ページにて正常に表示