### PR TITLE
古いラベルの一覧を見れるページを作成

### DIFF
--- a/web/browse/templates/browse/index.html
+++ b/web/browse/templates/browse/index.html
@@ -28,6 +28,11 @@
             </div>
           {% endfor %}
         </div>
+        <div class="column is narrow is narrow-padding">
+          <div class=" is-size-5-desktop is-size-6">
+            <a href="/label/">→もっと見る</a>
+          </div>
+        </div>
       </div>
     </div>
     <section class="section">

--- a/web/browse/templates/browse/index.html
+++ b/web/browse/templates/browse/index.html
@@ -28,9 +28,9 @@
             </div>
           {% endfor %}
         </div>
-        <div class="column is narrow is narrow-padding">
+        <div class="column is-narrow is-narrow-padding">
           <div class=" is-size-5-desktop is-size-6">
-            <a href="/label/">→もっと見る</a>
+            <a href="/label">→もっと見る</a>
           </div>
         </div>
       </div>

--- a/web/browse/templates/browse/label_index.html
+++ b/web/browse/templates/browse/label_index.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% load core_tags %}
+
+{% block page_title %}ラベル一覧{% endblock %}
+{% block ogp_page_title %}ラベル一覧{% endblock %}
+
+{% block content_2col %}
+  <div class="column is-multiline">
+    {% for label in labels %}
+      <div class="column is-one-third">
+        <a href="label/{{ label.slug }}">
+          <h1 class="title {{ label.css_classes }} is-size-3">
+            {{ label }}
+          </h1>
+        </a>
+        <div class="subtitle">{{ label.description|activate_url|safe }}</div>
+      </div>
+      {% include 'browse/components/video-list.html' with videos=label.videos column_classes='is-one-third' %}
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/web/browse/templates/browse/label_index.html
+++ b/web/browse/templates/browse/label_index.html
@@ -15,7 +15,8 @@
         </a>
         <div class="subtitle">{{ label.description|activate_url|safe }}</div>
       </div>
-      {% include 'browse/components/video-list.html' with videos=label.videos column_classes='is-one-third' %}
+      {% include 'browse/components/video-list.html' with videos=label.videos column_classes='is-one-third' page_obj=videos %}
     {% endfor %}
+  {% include 'base/components/pagination.html' %}
   </div>
 {% endblock %}

--- a/web/browse/templates/browse/label_index.html
+++ b/web/browse/templates/browse/label_index.html
@@ -7,15 +7,14 @@
 {% block content_2col %}
   <div class="column is-multiline">
     {% for label in labels %}
-      <div class="column is-one-third">
-        <a href="label/{{ label.slug }}">
+      <div class="column">
+        <a href="/label/{{ label.slug }}">
           <h1 class="title {{ label.css_classes }} is-size-3">
             {{ label }}
           </h1>
         </a>
         <div class="subtitle">{{ label.description|activate_url|safe }}</div>
       </div>
-      {% include 'browse/components/video-list.html' with videos=label.videos column_classes='is-one-third' page_obj=videos %}
     {% endfor %}
   {% include 'base/components/pagination.html' %}
   </div>

--- a/web/browse/urls.py
+++ b/web/browse/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('ranking', views.ranking),
     path('ranking/<slug:type>', views.ranking),
     path('ranking/<slug:type>/<slug:day>', views.ranking),
+    path('label', views.label_index),
     path('label/<slug:slug>', views.label),
 ]

--- a/web/browse/views.py
+++ b/web/browse/views.py
@@ -102,21 +102,10 @@ label = LabelList.as_view()
 class LabelIndex(AltPaginationListView):
     template_name = "browse/label_index.html"
     context_object_name = "labels"
-    paginate_by = 10
-    labels = None
-
-    def get(self, request, *args, **kwargs):
-        self.labels = Label.objects.all().order_by('-id')
-        for label in self.labels:
-            label.videos = safe_videos().filter(profile__labels=label).order_by('-published_at')[:3]
-        return super().get(request, *args, **kwargs)
+    paginate_by = 15
 
     def get_queryset(self):
-        return self.labels
-
-    def get_context_data(self, *args, **kwargs):
-        context = super().get_context_data(*args, **kwargs)
-        return context
+        return Label.objects.all().order_by('-id')
 
 
 label_index = LabelIndex.as_view()

--- a/web/browse/views.py
+++ b/web/browse/views.py
@@ -118,4 +118,5 @@ class LabelIndex(AltPaginationListView):
         context = super().get_context_data(*args, **kwargs)
         return context
 
+
 label_index = LabelIndex.as_view()

--- a/web/browse/views.py
+++ b/web/browse/views.py
@@ -97,3 +97,25 @@ class LabelList(AltPaginationListView):
 
 
 label = LabelList.as_view()
+
+
+class LabelIndex(AltPaginationListView):
+    template_name = "browse/label_index.html"
+    context_object_name = "labels"
+    paginate_by = 10
+    labels = None
+
+    def get(self, request, *args, **kwargs):
+        self.labels = Label.objects.all().order_by('id')
+        for label in self.labels:
+            label.videos = safe_videos().filter(profile__labels=label).order_by('-published_at')[:3]
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        return self.labels
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        return context
+
+label_index = LabelIndex.as_view()

--- a/web/browse/views.py
+++ b/web/browse/views.py
@@ -106,7 +106,7 @@ class LabelIndex(AltPaginationListView):
     labels = None
 
     def get(self, request, *args, **kwargs):
-        self.labels = Label.objects.all().order_by('id')
+        self.labels = Label.objects.all().order_by('-id')
         for label in self.labels:
             label.videos = safe_videos().filter(profile__labels=label).order_by('-published_at')[:3]
         return super().get(request, *args, **kwargs)


### PR DESCRIPTION
棒バトランキング2019等、古いラベルの一覧をユーザーが参照できるように一覧ページを作成するという話で「私がPRを送る」という流れに基づき、PRを作成しました
ご確認お願いします

# 全体的にどういう修正をしたか

* 古いラベルの一覧を見れるページを、/labelをアドレスとして作成
* トップページ上にあるラベル一覧の末尾に「もっと見る」を追加

# 作成したラベル一覧ページについて説明

* AltPaginationListViewの派生
* ラベル1つにつき以下の3つを用意し、それを10個のページネーション要素としている
1. 一番上にラベルをリンク付きタイトル(ここをクリックすることでラベル個別のページに飛べる)
2. 真ん中に説明文
3. 一番下に動画を新着順で3つ横並び
* ラベルの表示順は、新しいものほど先頭に近い(正確にはid順)